### PR TITLE
Column alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,29 @@
 Copy a table in Excel (or other spreadsheet programs) and paste it as a Markdown table.
 
 ![demo](https://cl.ly/120h1K2Q1Y3H/Screen%20Recording%202016-08-31%20at%2010.31%20PM.gif)
+
+## Column Alignments
+
+You can optionally specify column alignment information by prepending one of the following to the column heading names in Excel:
+
+* ^c  - center alignment
+* ^r  - right alignment
+* ^l   - left alignment (the default)
+
+For example: enter the following in Excel to right-align the second column and center-align the third column:
+
+| animal | ^rweight | ^ccolor  |
+|--------|----------|----------|
+| dog    | 30lb     | tan      |
+| dog    | 85lb     | black    |
+| cat    | 18lb     | calico   |
+
+This will produce the following markdown table when pasted:
+
+```markdown
+| animal | weight | color  |
+|--------|-------:|:------:|
+| dog    | 30lb   | tan    |
+| dog    | 85lb   | black  |
+| cat    | 18lb   | calico |
+```

--- a/script.js
+++ b/script.js
@@ -24,7 +24,24 @@ editor.addEventListener("paste", function(event) {
     console.log(row)
     return row.split("\t")
   })
+
+  var colAlignments = []
+
   var columnWidths = rows[0].map(function(column, columnIndex) {
+    var alignment = "l"
+    var re = /^(\^[lcr])/i
+    var m = column.match(re)
+    if (m) {
+        var align = m[1][1].toLowerCase()
+        if (align === "c") {
+          alignment = "c"
+        } else if (align === "r") {
+          alignment = "r"
+        }
+      }
+    colAlignments.push(alignment)
+    column = column.replace(re, "")
+    rows[0][columnIndex] = column
     return columnWidth(rows, columnIndex)
   })
   var markdownRows = rows.map(function(row, rowIndex) {
@@ -40,7 +57,19 @@ editor.addEventListener("paste", function(event) {
 
   })
   markdownRows.splice(1, 0, "|" + columnWidths.map(function(width, index) {
-    return Array(columnWidths[index] + 3).join("-")
+    var prefix = ""
+    var postfix = ""
+    var adjust = 0
+    var alignment = colAlignments[index]
+    if (alignment === "r") {
+      postfix = ":"
+      adjust = 1
+    } else if (alignment == "c") {
+      prefix = ":"
+      postfix = ":"
+      adjust = 2
+    }
+    return prefix + Array(columnWidths[index] + 3 - adjust).join("-") + postfix
   }).join("|") + "|")
 
   // https://www.w3.org/TR/clipboard-apis/#the-paste-action


### PR DESCRIPTION
This enables people to optionally specify column alignment information by prepending one of the following to the column heading names in Excel:

* ^c  - center alignment
* ^r  - right alignment
* ^l   - left alignment (the default)

For example: enter the following in Excel to right-align the second column and center-align the third column:

| animal | ^rweight | ^ccolor  |
|--------|----------|----------|
| dog    | 30lb     | tan      |
| dog    | 85lb     | black    |
| cat    | 18lb     | calico   |

This will produce the following markdown table when pasted:

```markdown
| animal | weight | color  |
|--------|-------:|:------:|
| dog    | 30lb   | tan    |
| dog    | 85lb   | black  |
| cat    | 18lb   | calico |
```