### PR TITLE
Don't trim empty cells at A1

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ function looksLikeTable(data) {
 
 editor.addEventListener("paste", function(event) {
   var clipboard = event.clipboardData
-  var data = clipboard.getData('text/plain').trim()
+  var data = clipboard.getData('text/plain')
 
   if(looksLikeTable(data)) {
     event.preventDefault()


### PR DESCRIPTION
Or the cells at the bottom right.

Fix #2.

The same examples now work:

| 1 | 2 | 3 |
|---|---|---|
| 4 | 5 | 6 |
| 7 | 8 | 9 |


|   | 2 | 3 |
|---|---|---|
| 4 | 5 | 6 |
| 7 | 8 | 9 |