### PR TITLE
FIXED: support for cells that have line breaks (Alt+Enter)

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,8 +20,8 @@ editor.addEventListener("paste", function(event) {
     return
   }
 
-  var rows = data.split((/[\n\u0085\u2028\u2029]|\r\n?/g)).map(function(row) {
-    console.log(row)
+  var rows = data.split((/[\u0085\u2028\u2029]|\r\n?/g)).map(function(row) {
+    row = row.replace('\n', ' ')
     return row.split("\t")
   })
   var columnWidths = rows[0].map(function(column, columnIndex) {


### PR DESCRIPTION
If you try to copy/paste cells that have line breaks:

```
script.js:5 Uncaught TypeError: Cannot read property 'length' of undefined
    at script.js:5
    at Array.map (<anonymous>)
    at columnWidth (script.js:4)
    at script.js:45
    at Array.map (<anonymous>)
    at HTMLTextAreaElement.<anonymous> (script.js:30)
```

I'm not sure why we need to split cells using '\n', if there is no need for that then this is a simple fix.
Otherwise, such cases need to be detected and handled in a more sophisticated way.