### PR TITLE
updates column width length check

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,7 +2,7 @@ var editor = document.getElementById("editor")
 
 function columnWidth(rows, columnIndex) {
   return Math.max.apply(null, rows.map(function(row) {
-    return row[columnIndex].length
+    return ('' + row[columnIndex]).length
   }))
 }
 


### PR DESCRIPTION
converts any cell value to string before performing length check to ensure length check works.

In chrome (`78.0.3904.70`), I was trying to paste in some content that must have had some characters that the length check didn't like.  Oddly enough, when performing the `row[columnIndex].length` check in the debugger it worked, but it only threw an error at runtime.  The error I received was

```
Uncaught TypeError: Cannot read property 'length' of undefined
    at script.js:5
    at Array.map (<anonymous>)
    at columnWidth (script.js:4)
    at script.js:28
    at Array.map (<anonymous>)
    at HTMLTextAreaElement.<anonymous> (script.js:27)
```